### PR TITLE
refactor: remove unnecessary state for animation

### DIFF
--- a/src/components/NotesMenu/index.tsx
+++ b/src/components/NotesMenu/index.tsx
@@ -4,23 +4,21 @@ import NotesPaletteToggler from '../NotesPaletteToggler';
 import { useState } from 'react';
 
 export default function NotesMenu() {
-  const [isHidden, setIsHidden] = useState<boolean>(true);
-  const [shouldAnimate, setShouldAnimate] = useState<boolean>(false);
+  const [isPaletteOpen, setIsPaletteOpen] = useState<boolean>(false);
+
+  const togglePalette = (isOpen: boolean): boolean => !isOpen;
 
   const togglePaletteMenu = () => {
-    setIsHidden((wasHidden: boolean): boolean => {
-      return !wasHidden;
-    });
-    setShouldAnimate((shouldAnimate: boolean): boolean => !shouldAnimate);
+    setIsPaletteOpen(togglePalette);
   };
 
   return (
     <section className="menu">
       <h2 className="visually-hidden">Notes Menu</h2>
       <div className="menu__wrapper">
-        <NotesPalette isHidden={isHidden} />
+        <NotesPalette isOpen={isPaletteOpen} />
         <NotesPaletteToggler
-          shouldAnimate={shouldAnimate}
+          shouldAnimate={isPaletteOpen}
           togglePalette={togglePaletteMenu}
         />
       </div>

--- a/src/components/NotesPalette/index.tsx
+++ b/src/components/NotesPalette/index.tsx
@@ -2,12 +2,12 @@ import './NotesPalette.scss';
 import NotesPaletteItem from '../NotesPaletteItem';
 
 interface NotesPaletteProps {
-  isHidden: boolean;
+  isOpen: boolean;
 }
 
-export default function NotesPalette({ isHidden }: NotesPaletteProps) {
+export default function NotesPalette({ isOpen }: NotesPaletteProps) {
   return (
-    <div className={`notes-palette${isHidden ? '--hidden' : ''}`}>
+    <div className={`notes-palette${!isOpen ? '--hidden' : ''}`}>
       <NotesPaletteItem variant="ocean" />
       <NotesPaletteItem variant="teal" />
       <NotesPaletteItem variant="mint" />


### PR DESCRIPTION
Change state to one declaration as this should work for both opening a palette and animating the palette switcher.